### PR TITLE
Updated #glow(boolean) to disenchant

### DIFF
--- a/src/main/java/me/mattstudios/mfgui/gui/components/ItemBuilder.java
+++ b/src/main/java/me/mattstudios/mfgui/gui/components/ItemBuilder.java
@@ -168,7 +168,8 @@ public final class ItemBuilder {
     }
 
     /**
-     * Makes the Item glow
+     * Changes the glow status of the item
+     * False removes all enchantments from item.
      *
      * @param glow Should the item glow
      * @return The ItemBuilder
@@ -179,6 +180,10 @@ public final class ItemBuilder {
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 
             return this;
+        }
+        
+        for (Enchantment enchantment : meta.getEnchants().keySet()) {
+            meta.removeEnchant(enchantment);
         }
 
         return this;


### PR DESCRIPTION
Previously, this would just leave the item in its original state. Therefore, if the item was enchanted before the glow(false) was redundant and kept the item enchanted. Now it will respect the boolean and disenchant the item too. 

Note: 
As far as I know it's impossible to solely remove the glow factor without removing enchantments as they are linked.
Thus add an enchant = glow, remove an enchant = no glow. There's no way to remove an enchant and keep the glow to my knowledge.